### PR TITLE
Support grasp contact

### DIFF
--- a/include/ForceColl/Constants.h
+++ b/include/ForceColl/Constants.h
@@ -1,0 +1,15 @@
+/* Author: Masaki Murooka */
+
+#pragma once
+
+namespace ForceColl
+{
+namespace constants
+{
+//! Default scale of force markers
+constexpr double defaultForceScale = 2e-3;
+
+//! Default scale of friction pyramid markers
+constexpr double defaultFricPyramidScale = 5e-2;
+} // namespace constants
+} // namespace ForceColl

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -103,6 +103,23 @@ public:
   std::vector<VertexWithRidge> vertexWithRidgeList_;
 };
 
+/** \brief Empty contact. */
+class EmptyContact : public Contact
+{
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /** \brief Constructor.
+      \param name name of contact
+   */
+  EmptyContact(const std::string & name);
+
+  /** \brief Constructor.
+      \param mcRtcConfig mc_rtc configuration
+  */
+  EmptyContact(const mc_rtc::Configuration & mcRtcConfig);
+};
+
 /** \brief Surface contact. */
 class SurfaceContact : public Contact
 {

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -93,11 +93,11 @@ public:
       \param forceScale scale of force markers (set non-positive for no visualization)
       \param fricPyramidScale scale of friction pyramid markers (set non-positive for no visualization)
    */
-  void addToGUI(mc_rtc::gui::StateBuilder & gui,
-                const std::vector<std::string> & category,
-                const Eigen::VectorXd & wrenchRatio,
-                double forceScale = constants::defaultForceScale,
-                double fricPyramidScale = constants::defaultFricPyramidScale);
+  virtual void addToGUI(mc_rtc::gui::StateBuilder & gui,
+                        const std::vector<std::string> & category,
+                        const Eigen::VectorXd & wrenchRatio,
+                        double forceScale = constants::defaultForceScale,
+                        double fricPyramidScale = constants::defaultFricPyramidScale);
 
 public:
   //! Name of contact
@@ -169,6 +169,19 @@ public:
   {
     return "Surface";
   }
+
+  /** \brief Add markers to GUI.
+      \param gui GUI
+      \param category category of GUI entries
+      \param wrenchRatio wrench ratio of each ridge
+      \param forceScale scale of force markers (set non-positive for no visualization)
+      \param fricPyramidScale scale of friction pyramid markers (set non-positive for no visualization)
+   */
+  virtual void addToGUI(mc_rtc::gui::StateBuilder & gui,
+                        const std::vector<std::string> & category,
+                        const Eigen::VectorXd & wrenchRatio,
+                        double forceScale = constants::defaultForceScale,
+                        double fricPyramidScale = constants::defaultFricPyramidScale) override;
 };
 
 /** \brief Grasp contact. */
@@ -207,5 +220,18 @@ public:
   {
     return "Grasp";
   }
+
+  /** \brief Add markers to GUI.
+      \param gui GUI
+      \param category category of GUI entries
+      \param wrenchRatio wrench ratio of each ridge
+      \param forceScale scale of force markers (set non-positive for no visualization)
+      \param fricPyramidScale scale of friction pyramid markers (set non-positive for no visualization)
+   */
+  virtual void addToGUI(mc_rtc::gui::StateBuilder & gui,
+                        const std::vector<std::string> & category,
+                        const Eigen::VectorXd & wrenchRatio,
+                        double forceScale = constants::defaultForceScale,
+                        double fricPyramidScale = constants::defaultFricPyramidScale) override;
 };
 } // namespace ForceColl

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -107,6 +107,11 @@ public:
 class SurfaceContact : public Contact
 {
 public:
+  /** \brief Load map of surface vertices in local coordinates
+      \param mcRtcConfig mc_rtc configuration
+  */
+  static void loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig);
+
   //! Map of surface vertices in local coordinates
   static inline std::unordered_map<std::string, std::vector<Eigen::Vector3d>> vertexListMap;
 
@@ -134,6 +139,11 @@ public:
 class GraspContact : public Contact
 {
 public:
+  /** \brief Load map of grasp vertices in local coordinates
+      \param mcRtcConfig mc_rtc configuration
+  */
+  static void loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig);
+
   //! Map of grasp vertices in local coordinates
   static inline std::unordered_map<std::string, std::vector<sva::PTransformd>> vertexListMap;
 

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -41,6 +41,8 @@ public:
   /** \brief Vertex with ridges. */
   struct VertexWithRidge
   {
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
     //! Vertex
     Eigen::Vector3d vertex;
 
@@ -70,6 +72,9 @@ public:
       \param name name of contact
    */
   Contact(const std::string & name);
+
+  /** \brief Get type of contact. */
+  virtual std::string type() const = 0;
 
   /** \brief Calculate wrench.
       \param wrenchRatio wrench ratio of each ridge
@@ -118,6 +123,12 @@ public:
       \param mcRtcConfig mc_rtc configuration
   */
   EmptyContact(const mc_rtc::Configuration & mcRtcConfig);
+
+  /** \brief Get type of contact. */
+  inline virtual std::string type() const override
+  {
+    return "Empty";
+  }
 };
 
 /** \brief Surface contact. */
@@ -150,6 +161,12 @@ public:
       \param mcRtcConfig mc_rtc configuration
   */
   SurfaceContact(const mc_rtc::Configuration & mcRtcConfig);
+
+  /** \brief Get type of contact. */
+  inline virtual std::string type() const override
+  {
+    return "Surface";
+  }
 };
 
 /** \brief Grasp contact. */
@@ -182,5 +199,11 @@ public:
       \param mcRtcConfig mc_rtc configuration
   */
   GraspContact(const mc_rtc::Configuration & mcRtcConfig);
+
+  /** \brief Get type of contact. */
+  inline virtual std::string type() const override
+  {
+    return "Grasp";
+  }
 };
 } // namespace ForceColl

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -110,10 +110,10 @@ public:
   /** \brief Load map of surface vertices in local coordinates
       \param mcRtcConfig mc_rtc configuration
   */
-  static void loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig);
+  static void loadVerticesMap(const mc_rtc::Configuration & mcRtcConfig);
 
   //! Map of surface vertices in local coordinates
-  static inline std::unordered_map<std::string, std::vector<Eigen::Vector3d>> vertexListMap;
+  static inline std::unordered_map<std::string, std::vector<Eigen::Vector3d>> verticesMap;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -121,12 +121,12 @@ public:
   /** \brief Constructor.
       \param name name of contact
       \param fricCoeff friction coefficient
-      \param localVertexList surface vertices in local coordinates
+      \param localVertices surface vertices in local coordinates
       \param pose pose of contact
    */
   SurfaceContact(const std::string & name,
                  double fricCoeff,
-                 const std::vector<Eigen::Vector3d> & localVertexList,
+                 const std::vector<Eigen::Vector3d> & localVertices,
                  const sva::PTransformd & pose);
 
   /** \brief Constructor.
@@ -142,10 +142,10 @@ public:
   /** \brief Load map of grasp vertices in local coordinates
       \param mcRtcConfig mc_rtc configuration
   */
-  static void loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig);
+  static void loadVerticesMap(const mc_rtc::Configuration & mcRtcConfig);
 
   //! Map of grasp vertices in local coordinates
-  static inline std::unordered_map<std::string, std::vector<sva::PTransformd>> vertexListMap;
+  static inline std::unordered_map<std::string, std::vector<sva::PTransformd>> verticesMap;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -153,12 +153,12 @@ public:
   /** \brief Constructor.
       \param name name of contact
       \param fricCoeff friction coefficient
-      \param localVertexList grasp vertices in local coordinates
+      \param localVertices grasp vertices in local coordinates
       \param pose pose of contact
    */
   GraspContact(const std::string & name,
                double fricCoeff,
-               const std::vector<sva::PTransformd> & localVertexList,
+               const std::vector<sva::PTransformd> & localVertices,
                const sva::PTransformd & pose);
 
   /** \brief Constructor.

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -6,6 +6,8 @@
 #include <mc_rtc/gui/StateBuilder.h>
 #include <SpaceVecAlg/SpaceVecAlg>
 
+#include <ForceColl/Constants.h>
+
 namespace ForceColl
 {
 /** \brief Friction pyramid. */
@@ -94,8 +96,8 @@ public:
   void addToGUI(mc_rtc::gui::StateBuilder & gui,
                 const std::vector<std::string> & category,
                 const Eigen::VectorXd & wrenchRatio,
-                double forceScale = 2e-3,
-                double fricPyramidScale = 5e-2);
+                double forceScale = constants::defaultForceScale,
+                double fricPyramidScale = constants::defaultFricPyramidScale);
 
 public:
   //! Name of contact

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -34,7 +34,7 @@ public:
   std::vector<Eigen::Vector3d> localRidgeList_;
 };
 
-/** \brief Contact constraint. */
+/** \brief Contact. */
 class Contact
 {
 public:
@@ -58,18 +58,18 @@ public:
   };
 
 public:
+  /** \brief Make shared pointer from mc_rtc configuration.
+      \param mcRtcConfig mc_rtc configuration
+  */
+  static std::shared_ptr<Contact> makeSharedFromConfig(const mc_rtc::Configuration & mcRtcConfig);
+
+public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
   /** \brief Constructor.
       \param name name of contact
-      \param fricCoeff friction coefficient
-      \param localVertexList vertices of surface in local coordinates
-      \param pose pose of contact
    */
-  Contact(const std::string & name,
-          double fricCoeff,
-          const std::vector<Eigen::Vector3d> & localVertexList,
-          const sva::PTransformd & pose);
+  Contact(const std::string & name);
 
   /** \brief Calculate wrench.
       \param wrenchRatio wrench ratio of each ridge
@@ -101,5 +101,32 @@ public:
 
   //! List of vertex with ridges
   std::vector<VertexWithRidge> vertexWithRidgeList_;
+};
+
+/** \brief Surface contact. */
+class SurfaceContact : public Contact
+{
+public:
+  //! Map of surface vertices in local coordinates
+  static inline std::unordered_map<std::string, std::vector<Eigen::Vector3d>> vertexListMap;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /** \brief Constructor.
+      \param name name of contact
+      \param fricCoeff friction coefficient
+      \param localVertexList surface vertices in local coordinates
+      \param pose pose of contact
+   */
+  SurfaceContact(const std::string & name,
+                 double fricCoeff,
+                 const std::vector<Eigen::Vector3d> & localVertexList,
+                 const sva::PTransformd & pose);
+
+  /** \brief Constructor.
+      \param mcRtcConfig mc_rtc configuration
+  */
+  SurfaceContact(const mc_rtc::Configuration & mcRtcConfig);
 };
 } // namespace ForceColl

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -89,15 +89,15 @@ public:
   /** \brief Add markers to GUI.
       \param gui GUI
       \param category category of GUI entries
-      \param wrenchRatio wrench ratio of each ridge
       \param forceScale scale of force markers (set non-positive for no visualization)
       \param fricPyramidScale scale of friction pyramid markers (set non-positive for no visualization)
+      \param wrenchRatio wrench ratio of each ridge
    */
   virtual void addToGUI(mc_rtc::gui::StateBuilder & gui,
                         const std::vector<std::string> & category,
-                        const Eigen::VectorXd & wrenchRatio,
                         double forceScale = constants::defaultForceScale,
-                        double fricPyramidScale = constants::defaultFricPyramidScale);
+                        double fricPyramidScale = constants::defaultFricPyramidScale,
+                        const Eigen::VectorXd & wrenchRatio = Eigen::VectorXd::Zero(0));
 
 public:
   //! Name of contact
@@ -173,15 +173,15 @@ public:
   /** \brief Add markers to GUI.
       \param gui GUI
       \param category category of GUI entries
-      \param wrenchRatio wrench ratio of each ridge
       \param forceScale scale of force markers (set non-positive for no visualization)
       \param fricPyramidScale scale of friction pyramid markers (set non-positive for no visualization)
+      \param wrenchRatio wrench ratio of each ridge
    */
   virtual void addToGUI(mc_rtc::gui::StateBuilder & gui,
                         const std::vector<std::string> & category,
-                        const Eigen::VectorXd & wrenchRatio,
                         double forceScale = constants::defaultForceScale,
-                        double fricPyramidScale = constants::defaultFricPyramidScale) override;
+                        double fricPyramidScale = constants::defaultFricPyramidScale,
+                        const Eigen::VectorXd & wrenchRatio = Eigen::VectorXd::Zero(0)) override;
 };
 
 /** \brief Grasp contact. */
@@ -224,14 +224,14 @@ public:
   /** \brief Add markers to GUI.
       \param gui GUI
       \param category category of GUI entries
-      \param wrenchRatio wrench ratio of each ridge
       \param forceScale scale of force markers (set non-positive for no visualization)
       \param fricPyramidScale scale of friction pyramid markers (set non-positive for no visualization)
+      \param wrenchRatio wrench ratio of each ridge
    */
   virtual void addToGUI(mc_rtc::gui::StateBuilder & gui,
                         const std::vector<std::string> & category,
-                        const Eigen::VectorXd & wrenchRatio,
                         double forceScale = constants::defaultForceScale,
-                        double fricPyramidScale = constants::defaultFricPyramidScale) override;
+                        double fricPyramidScale = constants::defaultFricPyramidScale,
+                        const Eigen::VectorXd & wrenchRatio = Eigen::VectorXd::Zero(0)) override;
 };
 } // namespace ForceColl

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -129,4 +129,31 @@ public:
   */
   SurfaceContact(const mc_rtc::Configuration & mcRtcConfig);
 };
+
+/** \brief Grasp contact. */
+class GraspContact : public Contact
+{
+public:
+  //! Map of grasp vertices in local coordinates
+  static inline std::unordered_map<std::string, std::vector<sva::PTransformd>> vertexListMap;
+
+public:
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  /** \brief Constructor.
+      \param name name of contact
+      \param fricCoeff friction coefficient
+      \param localVertexList grasp vertices in local coordinates
+      \param pose pose of contact
+   */
+  GraspContact(const std::string & name,
+               double fricCoeff,
+               const std::vector<sva::PTransformd> & localVertexList,
+               const sva::PTransformd & pose);
+
+  /** \brief Constructor.
+      \param mcRtcConfig mc_rtc configuration
+  */
+  GraspContact(const mc_rtc::Configuration & mcRtcConfig);
+};
 } // namespace ForceColl

--- a/include/ForceColl/WrenchDistribution.h
+++ b/include/ForceColl/WrenchDistribution.h
@@ -2,6 +2,7 @@
 
 #include <qp_solver_collection/QpSolverCollection.h>
 
+#include <ForceColl/Constants.h>
 #include <ForceColl/Contact.h>
 
 namespace ForceColl
@@ -70,8 +71,8 @@ public:
    */
   void addToGUI(mc_rtc::gui::StateBuilder & gui,
                 const std::vector<std::string> & category,
-                double forceScale = 2e-3,
-                double fricPyramidScale = 5e-2);
+                double forceScale = constants::defaultForceScale,
+                double fricPyramidScale = constants::defaultFricPyramidScale);
 
 public:
   //! List of contact constraint

--- a/include/ForceColl/WrenchDistribution.hpp
+++ b/include/ForceColl/WrenchDistribution.hpp
@@ -112,9 +112,8 @@ void WrenchDistribution<PatchID>::addToGUI(mc_rtc::gui::StateBuilder & gui,
 
   for(const auto & contactKV : contactList_)
   {
-    contactKV.second->addToGUI(gui, category,
-                               resultWrenchRatio_.segment(wrenchRatioIdx, contactKV.second->graspMat_.cols()),
-                               forceScale, fricPyramidScale);
+    contactKV.second->addToGUI(gui, category, forceScale, fricPyramidScale,
+                               resultWrenchRatio_.segment(wrenchRatioIdx, contactKV.second->graspMat_.cols()));
     wrenchRatioIdx += static_cast<int>(contactKV.second->graspMat_.cols());
   }
 }

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -78,9 +78,9 @@ sva::ForceVecd Contact::calcWrench(const Eigen::VectorXd & wrenchRatio, const Ei
 
 void Contact::addToGUI(mc_rtc::gui::StateBuilder & gui,
                        const std::vector<std::string> & category,
-                       const Eigen::VectorXd & wrenchRatio,
                        double forceScale,
-                       double fricPyramidScale)
+                       double fricPyramidScale,
+                       const Eigen::VectorXd & wrenchRatio)
 {
   if(forceScale > 0 || fricPyramidScale > 0)
   {
@@ -97,12 +97,19 @@ void Contact::addToGUI(mc_rtc::gui::StateBuilder & gui,
       std::vector<std::array<size_t, 3>> fricPyramidVertexIndicies;
       for(const auto & ridge : ridgeList)
       {
-        Eigen::Vector3d force = wrenchRatio(wrenchRatioIdx) * ridge;
-        vertexForce += force;
-        Eigen::Vector3d fricPyramidVertex = vertex + fricPyramidScale * ridge;
-        fricPyramidVertices.push_back(fricPyramidVertex);
-        fricPyramidVertexIndicies.push_back(
-            {0, static_cast<size_t>(ridgeIdx + 1), static_cast<size_t>(ridgeIdx + 1) % ridgeList.size() + 1});
+        if(forceScale > 0)
+        {
+          Eigen::Vector3d force = wrenchRatio(wrenchRatioIdx) * ridge;
+          vertexForce += force;
+        }
+
+        if(fricPyramidScale > 0)
+        {
+          Eigen::Vector3d fricPyramidVertex = vertex + fricPyramidScale * ridge;
+          fricPyramidVertices.push_back(fricPyramidVertex);
+          fricPyramidVertexIndicies.push_back(
+              {0, static_cast<size_t>(ridgeIdx + 1), static_cast<size_t>(ridgeIdx + 1) % ridgeList.size() + 1});
+        }
 
         wrenchRatioIdx++;
         ridgeIdx++;
@@ -198,11 +205,11 @@ SurfaceContact::SurfaceContact(const mc_rtc::Configuration & mcRtcConfig)
 
 void SurfaceContact::addToGUI(mc_rtc::gui::StateBuilder & gui,
                               const std::vector<std::string> & category,
-                              const Eigen::VectorXd & wrenchRatio,
                               double forceScale,
-                              double fricPyramidScale)
+                              double fricPyramidScale,
+                              const Eigen::VectorXd & wrenchRatio)
 {
-  Contact::addToGUI(gui, category, wrenchRatio, forceScale, fricPyramidScale);
+  Contact::addToGUI(gui, category, forceScale, fricPyramidScale, wrenchRatio);
 
   // Add region
   {
@@ -262,11 +269,11 @@ GraspContact::GraspContact(const mc_rtc::Configuration & mcRtcConfig)
 
 void GraspContact::addToGUI(mc_rtc::gui::StateBuilder & gui,
                             const std::vector<std::string> & category,
-                            const Eigen::VectorXd & wrenchRatio,
                             double forceScale,
-                            double fricPyramidScale)
+                            double fricPyramidScale,
+                            const Eigen::VectorXd & wrenchRatio)
 {
-  Contact::addToGUI(gui, category, wrenchRatio, forceScale, fricPyramidScale);
+  Contact::addToGUI(gui, category, forceScale, fricPyramidScale, wrenchRatio);
 
   // Add region
   {

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -29,7 +29,11 @@ std::vector<Eigen::Vector3d> FrictionPyramid::calcGlobalRidgeList(const Eigen::M
 
 std::shared_ptr<Contact> Contact::makeSharedFromConfig(const mc_rtc::Configuration & mcRtcConfig)
 {
-  if(mcRtcConfig("type") == "Surface")
+  if(mcRtcConfig("type") == "Empty")
+  {
+    return std::make_shared<EmptyContact>(mcRtcConfig);
+  }
+  else if(mcRtcConfig("type") == "Surface")
   {
     return std::make_shared<SurfaceContact>(mcRtcConfig);
   }
@@ -130,6 +134,17 @@ void Contact::addToGUI(mc_rtc::gui::StateBuilder & gui,
 
     vertexIdx++;
   }
+}
+
+EmptyContact::EmptyContact(const std::string & name) : Contact(name)
+{
+  // Set graspMat_ and vertexWithRidgeList_
+  graspMat_.setZero(6, 0);
+}
+
+EmptyContact::EmptyContact(const mc_rtc::Configuration & mcRtcConfig)
+: EmptyContact(static_cast<std::string>(mcRtcConfig("name")))
+{
 }
 
 void SurfaceContact::loadVerticesMap(const mc_rtc::Configuration & mcRtcConfig)

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -132,6 +132,14 @@ void Contact::addToGUI(mc_rtc::gui::StateBuilder & gui,
   }
 }
 
+void SurfaceContact::loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig)
+{
+  for(const auto & vertexListConfig : mcRtcConfig)
+  {
+    vertexListMap[vertexListConfig("name")] = vertexListConfig("vertices");
+  }
+}
+
 SurfaceContact::SurfaceContact(const std::string & name,
                                double fricCoeff,
                                const std::vector<Eigen::Vector3d> & localVertexList,
@@ -166,6 +174,14 @@ SurfaceContact::SurfaceContact(const mc_rtc::Configuration & mcRtcConfig)
                  vertexListMap.at(mcRtcConfig("vertexListName")),
                  mcRtcConfig("pose"))
 {
+}
+
+void GraspContact::loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig)
+{
+  for(const auto & vertexListConfig : mcRtcConfig)
+  {
+    vertexListMap[vertexListConfig("name")] = vertexListConfig("vertices");
+  }
 }
 
 GraspContact::GraspContact(const std::string & name,

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -132,30 +132,30 @@ void Contact::addToGUI(mc_rtc::gui::StateBuilder & gui,
   }
 }
 
-void SurfaceContact::loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig)
+void SurfaceContact::loadVerticesMap(const mc_rtc::Configuration & mcRtcConfig)
 {
-  for(const auto & vertexListConfig : mcRtcConfig)
+  for(const auto & verticesConfig : mcRtcConfig)
   {
-    vertexListMap[vertexListConfig("name")] = vertexListConfig("vertices");
+    verticesMap[verticesConfig("name")] = verticesConfig("vertices");
   }
 }
 
 SurfaceContact::SurfaceContact(const std::string & name,
                                double fricCoeff,
-                               const std::vector<Eigen::Vector3d> & localVertexList,
+                               const std::vector<Eigen::Vector3d> & localVertices,
                                const sva::PTransformd & pose)
 : Contact(name)
 {
   // Set graspMat_ and vertexWithRidgeList_
   FrictionPyramid fricPyramid(fricCoeff);
 
-  graspMat_.resize(6, localVertexList.size() * fricPyramid.ridgeNum());
+  graspMat_.resize(6, localVertices.size() * fricPyramid.ridgeNum());
 
   const auto & globalRidgeList = fricPyramid.calcGlobalRidgeList(pose.rotation().transpose());
 
-  for(size_t vertexIdx = 0; vertexIdx < localVertexList.size(); vertexIdx++)
+  for(size_t vertexIdx = 0; vertexIdx < localVertices.size(); vertexIdx++)
   {
-    Eigen::Vector3d globalVertex = (sva::PTransformd(localVertexList[vertexIdx]) * pose).translation();
+    Eigen::Vector3d globalVertex = (sva::PTransformd(localVertices[vertexIdx]) * pose).translation();
 
     for(size_t ridgeIdx = 0; ridgeIdx < globalRidgeList.size(); ridgeIdx++)
     {
@@ -171,33 +171,33 @@ SurfaceContact::SurfaceContact(const std::string & name,
 SurfaceContact::SurfaceContact(const mc_rtc::Configuration & mcRtcConfig)
 : SurfaceContact(mcRtcConfig("name"),
                  mcRtcConfig("fricCoeff"),
-                 vertexListMap.at(mcRtcConfig("vertexListName")),
+                 verticesMap.at(mcRtcConfig("verticesName")),
                  mcRtcConfig("pose"))
 {
 }
 
-void GraspContact::loadVertexListMap(const mc_rtc::Configuration & mcRtcConfig)
+void GraspContact::loadVerticesMap(const mc_rtc::Configuration & mcRtcConfig)
 {
-  for(const auto & vertexListConfig : mcRtcConfig)
+  for(const auto & verticesConfig : mcRtcConfig)
   {
-    vertexListMap[vertexListConfig("name")] = vertexListConfig("vertices");
+    verticesMap[verticesConfig("name")] = verticesConfig("vertices");
   }
 }
 
 GraspContact::GraspContact(const std::string & name,
                            double fricCoeff,
-                           const std::vector<sva::PTransformd> & localVertexList,
+                           const std::vector<sva::PTransformd> & localVertices,
                            const sva::PTransformd & pose)
 : Contact(name)
 {
   // Set graspMat_ and vertexWithRidgeList_
   FrictionPyramid fricPyramid(fricCoeff);
 
-  graspMat_.resize(6, localVertexList.size() * fricPyramid.ridgeNum());
+  graspMat_.resize(6, localVertices.size() * fricPyramid.ridgeNum());
 
-  for(size_t vertexIdx = 0; vertexIdx < localVertexList.size(); vertexIdx++)
+  for(size_t vertexIdx = 0; vertexIdx < localVertices.size(); vertexIdx++)
   {
-    sva::PTransformd globalVertexPose = localVertexList[vertexIdx] * pose;
+    sva::PTransformd globalVertexPose = localVertices[vertexIdx] * pose;
     Eigen::Vector3d globalVertex = globalVertexPose.translation();
     const auto & globalRidgeList = fricPyramid.calcGlobalRidgeList(globalVertexPose.rotation().transpose());
 
@@ -215,7 +215,7 @@ GraspContact::GraspContact(const std::string & name,
 GraspContact::GraspContact(const mc_rtc::Configuration & mcRtcConfig)
 : GraspContact(mcRtcConfig("name"),
                mcRtcConfig("fricCoeff"),
-               vertexListMap.at(mcRtcConfig("vertexListName")),
+               verticesMap.at(mcRtcConfig("verticesName")),
                mcRtcConfig("pose"))
 {
 }

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -41,6 +41,7 @@ std::shared_ptr<Contact> Contact::makeSharedFromConfig(const mc_rtc::Configurati
   {
     return std::make_shared<GraspContact>(mcRtcConfig);
   }
+  else
   {
     mc_rtc::log::error_and_throw<std::runtime_error>("[Contact::makeSharedFromConfig] Invalid type: {}.",
                                                      mcRtcConfig("type"));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ else()
 endif()
 
 set(ForceColl_gtest_list
+  TestContact
   TestWrenchDistribution
   )
 

--- a/tests/src/TestContact.cpp
+++ b/tests/src/TestContact.cpp
@@ -1,0 +1,77 @@
+/* Author: Masaki Murooka */
+
+#include <gtest/gtest.h>
+
+#include <ForceColl/Contact.h>
+
+TEST(TestContact, SurfaceContact)
+{
+  const std::string vertexListYamlStr = R"(
+- name: vertexListSample
+  vertices:
+    - [0, 0, 0]
+    - [0.1, -0.2, 0.3]
+)";
+  const std::string constructorYamlStr = R"(
+type: Surface
+name: ContactYaml
+fricCoeff: 1.0
+vertexListName: vertexListSample
+pose:
+  translation: [0.0, 0.5, -0.5]
+  rotation: [1.5707963267948966, 0, 0]
+)";
+
+  auto contactDirect = std::make_shared<ForceColl::SurfaceContact>(
+      "ContactDirect", 1.0, std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero(), Eigen::Vector3d(0.1, -0.2, 0.3)},
+      sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5)));
+
+  ForceColl::SurfaceContact::loadVertexListMap(mc_rtc::Configuration::fromYAMLData(vertexListYamlStr));
+  auto contactYaml = ForceColl::Contact::makeSharedFromConfig(mc_rtc::Configuration::fromYAMLData(constructorYamlStr));
+
+  EXPECT_LT((contactDirect->graspMat_ - contactYaml->graspMat_).norm(), 1e-8) << "contactDirect:\n"
+                                                                              << contactDirect->graspMat_ << std::endl
+                                                                              << "contactYaml:\n"
+                                                                              << contactYaml->graspMat_ << std::endl;
+}
+
+TEST(TestContact, GraspContact)
+{
+  const std::string vertexListYamlStr = R"(
+- name: vertexListSample
+  vertices:
+    - translation: [0.0, -0.05, 0.0]
+      rotation: [-1.5707963267948966, 0, 0]
+    - translation: [0.0, 0.05, 0.0]
+      rotation: [1.5707963267948966, 0, 0]
+)";
+  const std::string constructorYamlStr = R"(
+type: Grasp
+name: ContactYaml
+fricCoeff: 1.0
+vertexListName: vertexListSample
+pose:
+  translation: [0.0, 0.5, -0.5]
+  rotation: [0, 1.5707963267948966, 0]
+)";
+
+  auto contactDirect = std::make_shared<ForceColl::GraspContact>(
+      "ContactDirect", 1.0,
+      std::vector<sva::PTransformd>{sva::PTransformd(sva::RotX(-1 * M_PI / 2), Eigen::Vector3d(0.0, -0.05, 0.0)),
+                                    sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.05, 0.0))},
+      sva::PTransformd(sva::RotY(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5)));
+
+  ForceColl::GraspContact::loadVertexListMap(mc_rtc::Configuration::fromYAMLData(vertexListYamlStr));
+  auto contactYaml = ForceColl::Contact::makeSharedFromConfig(mc_rtc::Configuration::fromYAMLData(constructorYamlStr));
+
+  EXPECT_LT((contactDirect->graspMat_ - contactYaml->graspMat_).norm(), 1e-6) << "contactDirect:\n"
+                                                                              << contactDirect->graspMat_ << std::endl
+                                                                              << "contactYaml:\n"
+                                                                              << contactYaml->graspMat_ << std::endl;
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/src/TestContact.cpp
+++ b/tests/src/TestContact.cpp
@@ -6,8 +6,8 @@
 
 TEST(TestContact, SurfaceContact)
 {
-  const std::string vertexListYamlStr = R"(
-- name: vertexListSample
+  const std::string verticesYamlStr = R"(
+- name: verticesSample
   vertices:
     - [0, 0, 0]
     - [0.1, -0.2, 0.3]
@@ -16,7 +16,7 @@ TEST(TestContact, SurfaceContact)
 type: Surface
 name: ContactYaml
 fricCoeff: 1.0
-vertexListName: vertexListSample
+verticesName: verticesSample
 pose:
   translation: [0.0, 0.5, -0.5]
   rotation: [1.5707963267948966, 0, 0]
@@ -26,7 +26,7 @@ pose:
       "ContactDirect", 1.0, std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero(), Eigen::Vector3d(0.1, -0.2, 0.3)},
       sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5)));
 
-  ForceColl::SurfaceContact::loadVertexListMap(mc_rtc::Configuration::fromYAMLData(vertexListYamlStr));
+  ForceColl::SurfaceContact::loadVerticesMap(mc_rtc::Configuration::fromYAMLData(verticesYamlStr));
   auto contactYaml = ForceColl::Contact::makeSharedFromConfig(mc_rtc::Configuration::fromYAMLData(constructorYamlStr));
 
   EXPECT_LT((contactDirect->graspMat_ - contactYaml->graspMat_).norm(), 1e-8) << "contactDirect:\n"
@@ -37,8 +37,8 @@ pose:
 
 TEST(TestContact, GraspContact)
 {
-  const std::string vertexListYamlStr = R"(
-- name: vertexListSample
+  const std::string verticesYamlStr = R"(
+- name: verticesSample
   vertices:
     - translation: [0.0, -0.05, 0.0]
       rotation: [-1.5707963267948966, 0, 0]
@@ -49,7 +49,7 @@ TEST(TestContact, GraspContact)
 type: Grasp
 name: ContactYaml
 fricCoeff: 1.0
-vertexListName: vertexListSample
+verticesName: verticesSample
 pose:
   translation: [0.0, 0.5, -0.5]
   rotation: [0, 1.5707963267948966, 0]
@@ -61,7 +61,7 @@ pose:
                                     sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.05, 0.0))},
       sva::PTransformd(sva::RotY(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5)));
 
-  ForceColl::GraspContact::loadVertexListMap(mc_rtc::Configuration::fromYAMLData(vertexListYamlStr));
+  ForceColl::GraspContact::loadVerticesMap(mc_rtc::Configuration::fromYAMLData(verticesYamlStr));
   auto contactYaml = ForceColl::Contact::makeSharedFromConfig(mc_rtc::Configuration::fromYAMLData(constructorYamlStr));
 
   EXPECT_LT((contactDirect->graspMat_ - contactYaml->graspMat_).norm(), 1e-6) << "contactDirect:\n"

--- a/tests/src/TestContact.cpp
+++ b/tests/src/TestContact.cpp
@@ -4,6 +4,23 @@
 
 #include <ForceColl/Contact.h>
 
+TEST(TestContact, EmptyContact)
+{
+  const std::string constructorYamlStr = R"(
+type: Empty
+name: ContactYaml
+)";
+
+  auto contactDirect = std::make_shared<ForceColl::EmptyContact>(std::string("ContactDirect"));
+
+  auto contactYaml = ForceColl::Contact::makeSharedFromConfig(mc_rtc::Configuration::fromYAMLData(constructorYamlStr));
+
+  EXPECT_LT((contactDirect->graspMat_ - contactYaml->graspMat_).norm(), 1e-8) << "contactDirect:\n"
+                                                                              << contactDirect->graspMat_ << std::endl
+                                                                              << "contactYaml:\n"
+                                                                              << contactYaml->graspMat_ << std::endl;
+}
+
 TEST(TestContact, SurfaceContact)
 {
   const std::string verticesYamlStr = R"(

--- a/tests/src/TestWrenchDistribution.cpp
+++ b/tests/src/TestWrenchDistribution.cpp
@@ -4,28 +4,27 @@
 
 #include <ForceColl/WrenchDistribution.h>
 
-enum class Foot
+TEST(TestWrenchDistribution, TwoSurfaceContact)
 {
-  Left,
-  Right
-};
+  enum class Foot
+  {
+    Left,
+    Right
+  };
 
-TEST(TestWrenchDistribution, Test1)
-{
   double fricCoeff = 0.5;
-  auto leftContact = std::make_shared<ForceColl::SurfaceContact>(
-      "LeftContact", fricCoeff,
+  auto leftFootContact = std::make_shared<ForceColl::SurfaceContact>(
+      "LeftFootContact", fricCoeff,
       std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0),
                                    Eigen::Vector3d(0.1, 0.0, 0.0)},
       sva::PTransformd::Identity());
-  auto rightContact = std::make_shared<ForceColl::SurfaceContact>(
-      "RightContact", fricCoeff, std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero()},
-      sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(0, 0.5, 0.5)));
-  std::unordered_map<Foot, std::shared_ptr<ForceColl::Contact>> contactList = {{Foot::Left, leftContact},
-                                                                               {Foot::Right, rightContact}};
+  auto rightFootContact = std::make_shared<ForceColl::SurfaceContact>(
+      "RightFootContact", fricCoeff, std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero()},
+      sva::PTransformd(Eigen::Vector3d(0, -0.5, 0.5)));
+  std::unordered_map<Foot, std::shared_ptr<ForceColl::Contact>> contactList = {{Foot::Left, leftFootContact},
+                                                                               {Foot::Right, rightFootContact}};
 
-  sva::ForceVecd desiredTotalWrench =
-      sva::ForceVecd(Eigen::Vector3d(100.0, 0.0, 0.0), Eigen::Vector3d(0.0, 0.0, 500.0));
+  sva::ForceVecd desiredTotalWrench = sva::ForceVecd(Eigen::Vector3d(10.0, 0.0, 0.0), Eigen::Vector3d(0.0, 0.0, 500.0));
   auto wrenchDist = std::make_shared<ForceColl::WrenchDistribution<Foot>>(contactList);
   sva::ForceVecd resultTotalWrench = wrenchDist->run(desiredTotalWrench);
 
@@ -33,6 +32,82 @@ TEST(TestWrenchDistribution, Test1)
       << "desiredTotalWrench: " << desiredTotalWrench << std::endl
       << "resultTotalWrench: " << resultTotalWrench << std::endl;
   EXPECT_TRUE((wrenchDist->resultWrenchRatio_.array() > 0).all());
+  for(const auto & wrenchKV : wrenchDist->calcWrenchList())
+  {
+    EXPECT_GT(wrenchKV.second.vector().norm(), 1e-10);
+  }
+}
+
+TEST(TestWrenchDistribution, ContainsEmptyContact)
+{
+  using Limb = std::string;
+
+  double fricCoeff = 0.5;
+  auto leftFootContact = std::make_shared<ForceColl::SurfaceContact>(
+      "LeftFootContact", fricCoeff,
+      std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0),
+                                   Eigen::Vector3d(0.1, 0.0, 0.0)},
+      sva::PTransformd::Identity());
+  auto rightFootContact = std::make_shared<ForceColl::SurfaceContact>(
+      "RightFootContact", fricCoeff, std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero()},
+      sva::PTransformd(Eigen::Vector3d(0, -0.5, 0.5)));
+  auto leftHandContact = std::make_shared<ForceColl::EmptyContact>(std::string("LefttHandContact"));
+  std::unordered_map<Limb, std::shared_ptr<ForceColl::Contact>> contactList = {
+      {"LeftFoot", leftFootContact}, {"RightFoot", rightFootContact}, {"LeftHand", leftHandContact}};
+
+  sva::ForceVecd desiredTotalWrench = sva::ForceVecd(Eigen::Vector3d(10.0, 0.0, 0.0), Eigen::Vector3d(0.0, 0.0, 500.0));
+  auto wrenchDist = std::make_shared<ForceColl::WrenchDistribution<Limb>>(contactList);
+  sva::ForceVecd resultTotalWrench = wrenchDist->run(desiredTotalWrench);
+
+  EXPECT_LT((desiredTotalWrench.vector() - resultTotalWrench.vector()).norm(), 1e-2)
+      << "desiredTotalWrench: " << desiredTotalWrench << std::endl
+      << "resultTotalWrench: " << resultTotalWrench << std::endl;
+  EXPECT_TRUE((wrenchDist->resultWrenchRatio_.array() > 0).all());
+  for(const auto & wrenchKV : wrenchDist->calcWrenchList())
+  {
+    if(wrenchKV.first == "LeftHand")
+    {
+      EXPECT_LT(wrenchKV.second.vector().norm(), 1e-10);
+    }
+    else
+    {
+      EXPECT_GT(wrenchKV.second.vector().norm(), 1e-10);
+    }
+  }
+}
+
+TEST(TestWrenchDistribution, ContainsGraspContact)
+{
+  using Limb = std::string;
+
+  double fricCoeff = 0.5;
+  auto leftFootContact = std::make_shared<ForceColl::SurfaceContact>(
+      "LeftFootContact", fricCoeff,
+      std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0),
+                                   Eigen::Vector3d(0.1, 0.0, 0.0)},
+      sva::PTransformd::Identity());
+  auto rightFootContact = std::make_shared<ForceColl::SurfaceContact>(
+      "RightFootContact", fricCoeff, std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero()},
+      sva::PTransformd(Eigen::Vector3d(0, -0.5, 0.5)));
+  auto leftHandContact = std::make_shared<ForceColl::GraspContact>(
+      "LeftHandContact", fricCoeff,
+      std::vector<sva::PTransformd>{sva::PTransformd::Identity(), sva::PTransformd(sva::RotX(M_PI))},
+      sva::PTransformd(sva::RotY(M_PI / 2), Eigen::Vector3d(0.5, 0.5, 1.0)));
+  std::unordered_map<Limb, std::shared_ptr<ForceColl::Contact>> contactList = {
+      {"LeftFoot", leftFootContact}, {"RightFoot", rightFootContact}, {"LeftHand", leftHandContact}};
+
+  sva::ForceVecd desiredTotalWrench = sva::ForceVecd(Eigen::Vector3d(10.0, 0.0, 0.0), Eigen::Vector3d(0.0, 0.0, 500.0));
+  auto wrenchDist = std::make_shared<ForceColl::WrenchDistribution<Limb>>(contactList);
+  sva::ForceVecd resultTotalWrench = wrenchDist->run(desiredTotalWrench);
+
+  EXPECT_LT((desiredTotalWrench.vector() - resultTotalWrench.vector()).norm(), 1e-2)
+      << "desiredTotalWrench: " << desiredTotalWrench << std::endl
+      << "resultTotalWrench: " << resultTotalWrench << std::endl;
+  EXPECT_TRUE((wrenchDist->resultWrenchRatio_.array() > 0).all());
+  for(const auto & wrenchKV : wrenchDist->calcWrenchList())
+  {
+    EXPECT_GT(wrenchKV.second.vector().norm(), 1e-10);
+  }
 }
 
 int main(int argc, char ** argv)

--- a/tests/src/TestWrenchDistribution.cpp
+++ b/tests/src/TestWrenchDistribution.cpp
@@ -13,12 +13,12 @@ enum class Foot
 TEST(TestWrenchDistribution, Test1)
 {
   double fricCoeff = 0.5;
-  auto leftContact = std::make_shared<ForceColl::Contact>("LeftContact", fricCoeff,
-                                                          std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0),
-                                                                                       Eigen::Vector3d(-0.1, 0.1, 0.0),
-                                                                                       Eigen::Vector3d(0.1, 0.0, 0.0)},
-                                                          sva::PTransformd::Identity());
-  auto rightContact = std::make_shared<ForceColl::Contact>(
+  auto leftContact = std::make_shared<ForceColl::SurfaceContact>(
+      "LeftContact", fricCoeff,
+      std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0),
+                                   Eigen::Vector3d(0.1, 0.0, 0.0)},
+      sva::PTransformd::Identity());
+  auto rightContact = std::make_shared<ForceColl::SurfaceContact>(
       "RightContact", fricCoeff, std::vector<Eigen::Vector3d>{Eigen::Vector3d::Zero()},
       sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(0, 0.5, 0.5)));
   std::unordered_map<Foot, std::shared_ptr<ForceColl::Contact>> contactList = {{Foot::Left, leftContact},


### PR DESCRIPTION
Surface contact and grasp contact are handled via a common parent class. Grasp contact is used in MultiContactController.