### PR TITLE
Allow to specify a maximum wrench at a given contact

### DIFF
--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -93,6 +93,12 @@ public:
   sva::ForceVecd calcWrench(const Eigen::VectorXd & wrenchRatio,
                             const Eigen::Vector3d & momentOrigin = Eigen::Vector3d::Zero()) const;
 
+  /** \brief Calculate the local wrench
+      \param wrenchRatio wrench ratio of each ridge
+      \returns contact wrench in local frame
+   */
+  sva::ForceVecd calcLocalWrench(const Eigen::VectorXd & wrenchRatio) const;
+
   /** \brief Add markers to GUI.
       \param gui GUI
       \param category category of GUI entries
@@ -112,6 +118,9 @@ public:
 
   //! Grasp matrix
   Eigen::Matrix<double, 6, Eigen::Dynamic> graspMat_;
+
+  //! Local grasp matrix
+  Eigen::Matrix<double, 6, Eigen::Dynamic> localGraspMat_;
 
   //! List of vertex with ridges
   std::vector<VertexWithRidge> vertexWithRidgeList_;
@@ -266,6 +275,14 @@ sva::ForceVecd calcTotalWrench(const std::vector<std::shared_ptr<Contact>> & con
 std::vector<sva::ForceVecd> calcWrenchList(const std::vector<std::shared_ptr<Contact>> & contactList,
                                            const Eigen::VectorXd & wrenchRatio,
                                            const Eigen::Vector3d & momentOrigin = Eigen::Vector3d::Zero());
+
+/** \brief Calculate local contact wrench list
+    \param contactList list of contact constraint
+    \param wrenchRatio wrench ratio
+    \returns local contact wrench list
+*/
+std::vector<sva::ForceVecd> calcLocalWrenchList(const std::vector<std::shared_ptr<Contact>> & contactList,
+                                                const Eigen::VectorXd & wrenchRatio);
 
 /** \brief Calculate contact wrench list.
     \tparam MapType type of map container

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -72,8 +72,9 @@ public:
 
   /** \brief Constructor.
       \param name name of contact
+      \param maxWrench maximum wrench (absolute value) that can be accepted by this contact
    */
-  Contact(const std::string & name);
+  Contact(const std::string & name, std::optional<sva::ForceVecd> maxWrench = std::nullopt);
 
   /** \brief Get type of contact. */
   virtual std::string type() const = 0;
@@ -114,6 +115,9 @@ public:
 
   //! List of vertex with ridges
   std::vector<VertexWithRidge> vertexWithRidgeList_;
+
+  //! Maximum wrench that can be accepted by this contact
+  std::optional<sva::ForceVecd> maxWrench_;
 };
 
 /** \brief Empty contact. */
@@ -163,7 +167,8 @@ public:
   SurfaceContact(const std::string & name,
                  double fricCoeff,
                  const std::vector<Eigen::Vector3d> & localVertices,
-                 const sva::PTransformd & pose);
+                 const sva::PTransformd & pose,
+                 std::optional<sva::ForceVecd> maxWrench = std::nullopt);
 
   /** \brief Constructor.
       \param mcRtcConfig mc_rtc configuration
@@ -214,7 +219,8 @@ public:
   GraspContact(const std::string & name,
                double fricCoeff,
                const std::vector<sva::PTransformd> & localVertices,
-               const sva::PTransformd & pose);
+               const sva::PTransformd & pose,
+               std::optional<sva::ForceVecd> maxWrench = std::nullopt);
 
   /** \brief Constructor.
       \param mcRtcConfig mc_rtc configuration

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -72,7 +72,7 @@ public:
 
   /** \brief Constructor.
       \param name name of contact
-      \param maxWrench maximum wrench (absolute value) that can be accepted by this contact
+      \param maxWrench maximum wrench in local frame (absolute value) that can be accepted by this contact
    */
   Contact(const std::string & name, std::optional<sva::ForceVecd> maxWrench = std::nullopt);
 
@@ -125,7 +125,7 @@ public:
   //! List of vertex with ridges
   std::vector<VertexWithRidge> vertexWithRidgeList_;
 
-  //! Maximum wrench that can be accepted by this contact
+  //! Maximum wrench in local frame that can be accepted by this contact
   std::optional<sva::ForceVecd> maxWrench_;
 };
 
@@ -172,6 +172,7 @@ public:
       \param fricCoeff friction coefficient
       \param localVertices surface vertices in local coordinates
       \param pose pose of contact
+      \param maxWrench maximum wrench in local frame (absolute value) that can be accepted by this contact
    */
   SurfaceContact(const std::string & name,
                  double fricCoeff,
@@ -224,6 +225,7 @@ public:
       \param fricCoeff friction coefficient
       \param localVertices grasp vertices in local coordinates
       \param pose pose of contact
+      \param maxWrench maximum wrench in local frame (absolute value) that can be accepted by this contact
    */
   GraspContact(const std::string & name,
                double fricCoeff,

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -160,6 +160,7 @@ EmptyContact::EmptyContact(const std::string & name) : Contact(name)
 {
   // Set graspMat_ and vertexWithRidgeList_
   graspMat_.setZero(6, 0);
+  localGraspMat_.setZero(6, 0);
 }
 
 EmptyContact::EmptyContact(const mc_rtc::Configuration & mcRtcConfig)
@@ -199,7 +200,8 @@ SurfaceContact::SurfaceContact(const std::string & name,
     {
       const auto & localRidge = fricPyramid.localRidgeList_[ridgeIdx];
       const auto & globalRidge = globalRidgeList[ridgeIdx];
-      auto colIdx = static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid.ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      auto colIdx =
+          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid.ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       localGraspMat_.col(colIdx) << localVertex.cross(localRidge), localRidge;
       graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
@@ -272,7 +274,8 @@ GraspContact::GraspContact(const std::string & name,
     {
       const auto & localRidge = localRidgeList[ridgeIdx];
       const auto & globalRidge = globalRidgeList[ridgeIdx];
-      auto colIdx = static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid.ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      auto colIdx =
+          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid.ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       localGraspMat_.col(colIdx) << localVertex.cross(localRidge), localRidge;
       graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
@@ -330,7 +333,7 @@ std::vector<sva::ForceVecd> ForceColl::calcWrenchList(const std::vector<std::sha
 {
   std::vector<sva::ForceVecd> wrenchList;
   wrenchList.reserve(contactList.size());
-  int wrenchRatioIdx = 0;
+  Eigen::DenseIndex wrenchRatioIdx = 0;
   for(const auto & contact : contactList)
   {
     wrenchList.push_back(contact->calcWrench(wrenchRatio.segment(wrenchRatioIdx, contact->ridgeNum()), momentOrigin));
@@ -339,7 +342,8 @@ std::vector<sva::ForceVecd> ForceColl::calcWrenchList(const std::vector<std::sha
   return wrenchList;
 }
 
-std::vector<sva::ForceVecd> ForceColl::calcLocalWrenchList(const std::vector<std::shared_ptr<Contact>> & contactList, const Eigen::VectorXd & wrenchRatio)
+std::vector<sva::ForceVecd> ForceColl::calcLocalWrenchList(const std::vector<std::shared_ptr<Contact>> & contactList,
+                                                           const Eigen::VectorXd & wrenchRatio)
 {
   std::vector<sva::ForceVecd> wrenchList;
   wrenchList.reserve(contactList.size());

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -50,7 +50,9 @@ std::shared_ptr<Contact> Contact::makeSharedFromConfig(const mc_rtc::Configurati
   }
 }
 
-Contact::Contact(const std::string & name) : name_(name) {}
+Contact::Contact(const std::string & name, std::optional<sva::ForceVecd> maxWrench) : name_(name), maxWrench_(maxWrench)
+{
+}
 
 sva::ForceVecd Contact::calcWrench(const Eigen::VectorXd & wrenchRatio, const Eigen::Vector3d & momentOrigin) const
 {
@@ -170,8 +172,9 @@ void SurfaceContact::loadVerticesMap(const mc_rtc::Configuration & mcRtcConfig)
 SurfaceContact::SurfaceContact(const std::string & name,
                                double fricCoeff,
                                const std::vector<Eigen::Vector3d> & localVertices,
-                               const sva::PTransformd & pose)
-: Contact(name)
+                               const sva::PTransformd & pose,
+                               std::optional<sva::ForceVecd> maxWrench)
+: Contact(name, std::move(maxWrench))
 {
   // Set graspMat_ and vertexWithRidgeList_
   FrictionPyramid fricPyramid(fricCoeff);
@@ -199,7 +202,8 @@ SurfaceContact::SurfaceContact(const mc_rtc::Configuration & mcRtcConfig)
 : SurfaceContact(mcRtcConfig("name"),
                  mcRtcConfig("fricCoeff"),
                  verticesMap.at(mcRtcConfig("verticesName")),
-                 mcRtcConfig("pose"))
+                 mcRtcConfig("pose"),
+                 mcRtcConfig("maxWrench", std::optional<sva::ForceVecd>{}))
 {
 }
 
@@ -234,8 +238,9 @@ void GraspContact::loadVerticesMap(const mc_rtc::Configuration & mcRtcConfig)
 GraspContact::GraspContact(const std::string & name,
                            double fricCoeff,
                            const std::vector<sva::PTransformd> & localVertices,
-                           const sva::PTransformd & pose)
-: Contact(name)
+                           const sva::PTransformd & pose,
+                           std::optional<sva::ForceVecd> maxWrench)
+: Contact(name, std::move(maxWrench))
 {
   // Set graspMat_ and vertexWithRidgeList_
   FrictionPyramid fricPyramid(fricCoeff);
@@ -263,7 +268,8 @@ GraspContact::GraspContact(const mc_rtc::Configuration & mcRtcConfig)
 : GraspContact(mcRtcConfig("name"),
                mcRtcConfig("fricCoeff"),
                verticesMap.at(mcRtcConfig("verticesName")),
-               mcRtcConfig("pose"))
+               mcRtcConfig("pose"),
+               mcRtcConfig("maxWrench", std::optional<sva::ForceVecd>{}))
 {
 }
 

--- a/src/WrenchDistribution.cpp
+++ b/src/WrenchDistribution.cpp
@@ -47,11 +47,12 @@ sva::ForceVecd WrenchDistribution::run(const sva::ForceVecd & desiredTotalWrench
   // Resize QP if needed
   {
     int varDim = static_cast<int>(resultWrenchRatio_.size());
-    int nIneq = std::accumulate(contactList_.begin(), contactList_.end(), 0,
-                                [](int ineq, const auto & contact) { return ineq + (contact->maxWrench_ ? 12 : 0); });
-    if(qpCoeff_.dim_var_ != varDim || qpCoeff_.dim_ineq_ != nIneq)
+    int ineqDim = std::accumulate(contactList_.begin(), contactList_.end(), 0, [](int _ineqDim, const auto & contact) {
+      return _ineqDim + (contact->maxWrench_ ? 12 : 0);
+    });
+    if(qpCoeff_.dim_var_ != varDim || qpCoeff_.dim_ineq_ != ineqDim)
     {
-      qpCoeff_.setup(varDim, 0, nIneq);
+      qpCoeff_.setup(varDim, 0, ineqDim);
     }
     if(qpCoeff_.dim_ineq_ != 0)
     {

--- a/src/WrenchDistribution.cpp
+++ b/src/WrenchDistribution.cpp
@@ -1,5 +1,8 @@
 #include <ForceColl/WrenchDistribution.h>
 
+// std::accumulate
+#include <numeric>
+
 using namespace ForceColl;
 
 void WrenchDistribution::Configuration::load(const mc_rtc::Configuration & mcRtcConfig)
@@ -41,6 +44,17 @@ sva::ForceVecd WrenchDistribution::run(const sva::ForceVecd & desiredTotalWrench
     return resultTotalWrench_;
   }
 
+  // Resize QP if needed
+  {
+    int varDim = static_cast<int>(resultWrenchRatio_.size());
+    int nIneq = std::accumulate(contactList_.begin(), contactList_.end(), 0,
+                                [](int ineq, const auto & contact) { return ineq + (contact->maxWrench_ ? 12 : 0); });
+    if(qpCoeff_.dim_var_ != varDim || qpCoeff_.dim_ineq_ != nIneq)
+    {
+      qpCoeff_.setup(varDim, 0, nIneq);
+    }
+  }
+
   // Construct totalGraspMat
   Eigen::Matrix<double, 6, Eigen::Dynamic> totalGraspMat(6, resultWrenchRatio_.size());
   {
@@ -62,17 +76,33 @@ sva::ForceVecd WrenchDistribution::run(const sva::ForceVecd & desiredTotalWrench
 
   // Solve QP
   {
-    int varDim = static_cast<int>(resultWrenchRatio_.size());
-    if(qpCoeff_.dim_var_ != varDim)
-    {
-      qpCoeff_.setup(varDim, 0, 0);
-    }
     Eigen::MatrixXd weightMat = config_.wrenchWeight.vector().asDiagonal();
     qpCoeff_.obj_mat_.noalias() = totalGraspMat.transpose() * weightMat * totalGraspMat;
     qpCoeff_.obj_mat_.diagonal().array() += config_.regularWeight;
     qpCoeff_.obj_vec_.noalias() = -1 * totalGraspMat.transpose() * weightMat * desiredTotalWrench_.vector();
-    qpCoeff_.x_min_.setConstant(varDim, config_.ridgeForceMinMax.first);
-    qpCoeff_.x_max_.setConstant(varDim, config_.ridgeForceMinMax.second);
+    qpCoeff_.x_min_.setConstant(qpCoeff_.dim_var_, config_.ridgeForceMinMax.first);
+    qpCoeff_.x_max_.setConstant(qpCoeff_.dim_var_, config_.ridgeForceMinMax.second);
+    if(qpCoeff_.dim_ineq_ != 0)
+    {
+      qpCoeff_.ineq_mat_.setZero();
+      int contactCol = 0;
+      int ineqRow = 0;
+      for(const auto & contact : contactList_)
+      {
+        if(contact->maxWrench_)
+        {
+          const auto & maxWrench = contact->maxWrench_->vector();
+          qpCoeff_.ineq_mat_.block(ineqRow, contactCol, 6, contact->ridgeNum()).noalias() =
+              -totalGraspMat.middleCols(contactCol, contact->ridgeNum());
+          qpCoeff_.ineq_mat_.block(ineqRow + 6, contactCol, 6, contact->ridgeNum()).noalias() =
+              totalGraspMat.middleCols(contactCol, contact->ridgeNum());
+          qpCoeff_.ineq_vec_.segment(ineqRow, 6) = maxWrench;
+          qpCoeff_.ineq_vec_.segment(ineqRow + 6, 6) = maxWrench;
+          ineqRow += 12;
+        }
+        contactCol += contact->ridgeNum();
+      }
+    }
     resultWrenchRatio_ = qpSolver_->solve(qpCoeff_);
   }
 

--- a/tests/src/TestWrenchDistribution.cpp
+++ b/tests/src/TestWrenchDistribution.cpp
@@ -100,6 +100,7 @@ void do_TestWrenchDistribution_ContainsGraspContact()
       << "resultTotalWrench: " << resultTotalWrench << std::endl;
   EXPECT_TRUE((wrenchDist->resultWrenchRatio_.array() > 0).all());
   auto wrenchList = ForceColl::calcWrenchList(contactList, wrenchDist->resultWrenchRatio_);
+  auto localWrenchList = ForceColl::calcLocalWrenchList(contactList, wrenchDist->resultWrenchRatio_);
   for(size_t i = 0; i < contactList.size(); ++i)
   {
     const auto & contact = contactList[i];
@@ -107,10 +108,11 @@ void do_TestWrenchDistribution_ContainsGraspContact()
     EXPECT_GT(wrench.vector().norm(), 1e-10);
     if(contact->maxWrench_)
     {
+      const auto & localWrench = localWrenchList[i];
       for(Eigen::DenseIndex i = 0; i < 3; ++i)
       {
-        EXPECT_LT(std::fabs(wrench.force()(i)), contact->maxWrench_->force()(i) + 1e-6);
-        EXPECT_LT(std::fabs(wrench.couple()(i)), contact->maxWrench_->couple()(i) + 1e-6);
+        EXPECT_LT(std::fabs(localWrench.force()(i)), contact->maxWrench_->force()(i) + 1e-6);
+        EXPECT_LT(std::fabs(localWrench.couple()(i)), contact->maxWrench_->couple()(i) + 1e-6);
       }
     }
   }


### PR DESCRIPTION
This PR adds the ability to specify limits on the wrench that can be distributed on a given contact. This is especially useful when mixing hands/feet contacts.

The first commit implements this in the global frame but after considering it and exchanging with @orikuma it seems to be more useful to specify the constraint in the local frame so the second commit does that.

If the constraint is not used this has no impact on the current behavior.

The initial approach has almost no impact on the runtime whereas the local approach requires to always compute the `localGraspMat_` in case the local wrench is requested or the wrench constraint is added later on.