### PR TITLE
Add function to update global vertices outside the constructor

### DIFF
--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -157,7 +157,8 @@ public:
     return "Empty";
   }
 
-  inline virtual void updateGlobalVertices(const sva::PTransformd & pose) {}
+  /** \brief Do nothing because EmptyContact does not have any vertices. */
+  inline virtual void updateGlobalVertices(const sva::PTransformd & pose) override {}
 };
 
 /** \brief Surface contact. */
@@ -203,7 +204,7 @@ public:
   }
 
   /** \brief Update graspMat_ and vertexWithRidgeList_ according to the input pose. */
-  virtual void updateGlobalVertices(const sva::PTransformd & pose);
+  virtual void updateGlobalVertices(const sva::PTransformd & pose) override;
 
   /** \brief Add markers to GUI.
       \param gui GUI
@@ -262,7 +263,7 @@ public:
   }
 
   /** \brief Update graspMat_ and vertexWithRidgeList_ according to the input pose. */
-  virtual void updateGlobalVertices(const sva::PTransformd & pose);
+  virtual void updateGlobalVertices(const sva::PTransformd & pose) override;
 
   /** \brief Add markers to GUI.
       \param gui GUI

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -85,6 +85,9 @@ public:
     return static_cast<int>(graspMat_.cols());
   }
 
+  /** \brief Update graspMat_ and vertexWithRidgeList_ according to the input pose. */
+  virtual void updateGlobalVertices(const sva::PTransformd & pose) = 0;
+
   /** \brief Calculate wrench.
       \param wrenchRatio wrench ratio of each ridge
       \param momentOrigin moment origin
@@ -122,7 +125,10 @@ public:
   //! Local grasp matrix
   Eigen::Matrix<double, 6, Eigen::Dynamic> localGraspMat_;
 
-  //! List of vertex with ridges
+  //! Friction pyramid
+  std::shared_ptr<FrictionPyramid> fricPyramid_;
+
+  //! List of global vertex with ridges
   std::vector<VertexWithRidge> vertexWithRidgeList_;
 
   //! Maximum wrench in local frame that can be accepted by this contact
@@ -150,6 +156,10 @@ public:
   {
     return "Empty";
   }
+
+  inline virtual void updateGlobalVertices(const sva::PTransformd & pose)
+  {
+  }
 };
 
 /** \brief Surface contact. */
@@ -163,6 +173,9 @@ public:
 
   //! Map of surface vertices in local coordinates
   static inline std::unordered_map<std::string, std::vector<Eigen::Vector3d>> verticesMap;
+
+  //! List of local verticies
+  std::vector<Eigen::Vector3d> localVertices_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -191,6 +204,9 @@ public:
     return "Surface";
   }
 
+  /** \brief Update graspMat_ and vertexWithRidgeList_ according to the input pose. */
+  virtual void updateGlobalVertices(const sva::PTransformd & pose);
+
   /** \brief Add markers to GUI.
       \param gui GUI
       \param category category of GUI entries
@@ -216,6 +232,9 @@ public:
 
   //! Map of grasp vertices in local coordinates
   static inline std::unordered_map<std::string, std::vector<sva::PTransformd>> verticesMap;
+
+  //! List of local verticies
+  std::vector<sva::PTransformd> localVertices_;
 
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -243,6 +262,9 @@ public:
   {
     return "Grasp";
   }
+
+  /** \brief Update graspMat_ and vertexWithRidgeList_ according to the input pose. */
+  virtual void updateGlobalVertices(const sva::PTransformd & pose);
 
   /** \brief Add markers to GUI.
       \param gui GUI

--- a/include/ForceColl/Contact.h
+++ b/include/ForceColl/Contact.h
@@ -157,9 +157,7 @@ public:
     return "Empty";
   }
 
-  inline virtual void updateGlobalVertices(const sva::PTransformd & pose)
-  {
-  }
+  inline virtual void updateGlobalVertices(const sva::PTransformd & pose) {}
 };
 
 /** \brief Surface contact. */

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -183,32 +183,27 @@ SurfaceContact::SurfaceContact(const std::string & name,
                                std::optional<sva::ForceVecd> maxWrench)
 : Contact(name, std::move(maxWrench))
 {
-  // Set graspMat_ and vertexWithRidgeList_
-  FrictionPyramid fricPyramid(fricCoeff);
+  // Set graspMat_ and localRidgeList_
+  fricPyramid_ = std::make_shared<FrictionPyramid>(fricCoeff);
 
-  graspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices.size()) * fricPyramid.ridgeNum());
-  localGraspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices.size()) * fricPyramid.ridgeNum());
+  localVertices_.resize(localVertices.size());
+  std::copy(localVertices.begin(), localVertices.end(), localVertices_.begin());
 
-  const auto & globalRidgeList = fricPyramid.calcGlobalRidgeList(pose.rotation().transpose());
-
-  for(size_t vertexIdx = 0; vertexIdx < localVertices.size(); vertexIdx++)
+  localGraspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices_.size()) * fricPyramid_->ridgeNum());
+  for(size_t vertexIdx = 0; vertexIdx < localVertices_.size(); vertexIdx++)
   {
-    const auto & localVertex = localVertices[vertexIdx];
-    Eigen::Vector3d globalVertex = (sva::PTransformd(localVertex) * pose).translation();
-
-    for(size_t ridgeIdx = 0; ridgeIdx < globalRidgeList.size(); ridgeIdx++)
+    const auto & localVertex = localVertices_[vertexIdx];
+    for(size_t ridgeIdx = 0; ridgeIdx < fricPyramid_->localRidgeList_.size(); ridgeIdx++)
     {
-      const auto & localRidge = fricPyramid.localRidgeList_[ridgeIdx];
-      const auto & globalRidge = globalRidgeList[ridgeIdx];
+      const auto & localRidge = fricPyramid_->localRidgeList_[ridgeIdx];
       auto colIdx =
-          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid.ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       localGraspMat_.col(colIdx) << localVertex.cross(localRidge), localRidge;
-      graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
     }
-
-    vertexWithRidgeList_.push_back(VertexWithRidge(globalVertex, globalRidgeList));
   }
+
+  updateGlobalVertices(pose);
 }
 
 SurfaceContact::SurfaceContact(const mc_rtc::Configuration & mcRtcConfig)
@@ -218,6 +213,31 @@ SurfaceContact::SurfaceContact(const mc_rtc::Configuration & mcRtcConfig)
                  mcRtcConfig("pose"),
                  mcRtcConfig("maxWrench", std::optional<sva::ForceVecd>{}))
 {
+}
+
+void SurfaceContact::updateGlobalVertices(const sva::PTransformd & pose)
+{
+  graspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices_.size()) * fricPyramid_->ridgeNum());
+  vertexWithRidgeList_.clear();
+
+  const auto & globalRidgeList = fricPyramid_->calcGlobalRidgeList(pose.rotation().transpose());
+
+  for(size_t vertexIdx = 0; vertexIdx < localVertices_.size(); vertexIdx++)
+  {
+    const auto & localVertex = localVertices_[vertexIdx];
+    Eigen::Vector3d globalVertex = (sva::PTransformd(localVertex) * pose).translation();
+
+    for(size_t ridgeIdx = 0; ridgeIdx < globalRidgeList.size(); ridgeIdx++)
+    {
+      const auto & globalRidge = globalRidgeList[ridgeIdx];
+      auto colIdx =
+        static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      // The top 3 rows are moment, the bottom 3 rows are force.
+      graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
+    }
+
+    vertexWithRidgeList_.push_back(VertexWithRidge(globalVertex, globalRidgeList));
+  }
 }
 
 void SurfaceContact::addToGUI(mc_rtc::gui::StateBuilder & gui,
@@ -255,34 +275,30 @@ GraspContact::GraspContact(const std::string & name,
                            std::optional<sva::ForceVecd> maxWrench)
 : Contact(name, std::move(maxWrench))
 {
-  // Set graspMat_ and vertexWithRidgeList_
-  FrictionPyramid fricPyramid(fricCoeff);
+  // Set graspMat_ and localRidgeList_
+  fricPyramid_ = std::make_shared<FrictionPyramid>(fricCoeff);
 
-  graspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices.size()) * fricPyramid.ridgeNum());
-  localGraspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices.size()) * fricPyramid.ridgeNum());
+  localVertices_.resize(localVertices.size());
+  std::copy(localVertices.begin(), localVertices.end(), localVertices_.begin());
 
-  for(size_t vertexIdx = 0; vertexIdx < localVertices.size(); vertexIdx++)
+  localGraspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices_.size()) * fricPyramid_->ridgeNum());
+
+  for(size_t vertexIdx = 0; vertexIdx < localVertices_.size(); vertexIdx++)
   {
-    const auto & localVertexPose = localVertices[vertexIdx];
-    sva::PTransformd globalVertexPose = localVertices[vertexIdx] * pose;
+    const auto & localVertexPose = localVertices_[vertexIdx];
     const auto & localVertex = localVertexPose.translation();
-    const auto & localRidgeList = fricPyramid.calcGlobalRidgeList(localVertexPose.rotation().transpose());
-    const auto & globalVertex = globalVertexPose.translation();
-    const auto & globalRidgeList = fricPyramid.calcGlobalRidgeList(globalVertexPose.rotation().transpose());
-
-    for(size_t ridgeIdx = 0; ridgeIdx < globalRidgeList.size(); ridgeIdx++)
+    const auto & localRidgeList = fricPyramid_->calcGlobalRidgeList(localVertexPose.rotation().transpose());
+    for(size_t ridgeIdx = 0; ridgeIdx < localRidgeList.size(); ridgeIdx++)
     {
       const auto & localRidge = localRidgeList[ridgeIdx];
-      const auto & globalRidge = globalRidgeList[ridgeIdx];
       auto colIdx =
-          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid.ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       localGraspMat_.col(colIdx) << localVertex.cross(localRidge), localRidge;
-      graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
     }
-
-    vertexWithRidgeList_.push_back(VertexWithRidge(globalVertex, globalRidgeList));
   }
+
+  updateGlobalVertices(pose);
 }
 
 GraspContact::GraspContact(const mc_rtc::Configuration & mcRtcConfig)
@@ -292,6 +308,31 @@ GraspContact::GraspContact(const mc_rtc::Configuration & mcRtcConfig)
                mcRtcConfig("pose"),
                mcRtcConfig("maxWrench", std::optional<sva::ForceVecd>{}))
 {
+}
+
+void GraspContact::updateGlobalVertices(const sva::PTransformd & pose)
+{
+  graspMat_.resize(6, static_cast<Eigen::DenseIndex>(localVertices_.size()) * fricPyramid_->ridgeNum());
+  vertexWithRidgeList_.clear();
+
+  for(size_t vertexIdx = 0; vertexIdx < localVertices_.size(); vertexIdx++)
+  {
+    const auto & localVertexPose = localVertices_[vertexIdx];
+    sva::PTransformd globalVertexPose = sva::PTransformd(localVertexPose) * pose;
+    const auto & globalVertex = globalVertexPose.translation();
+    const auto & globalRidgeList = fricPyramid_->calcGlobalRidgeList(globalVertexPose.rotation().transpose());
+
+    for(size_t ridgeIdx = 0; ridgeIdx < globalRidgeList.size(); ridgeIdx++)
+    {
+      const auto & globalRidge = globalRidgeList[ridgeIdx];
+      auto colIdx =
+          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      // The top 3 rows are moment, the bottom 3 rows are force.
+      graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
+    }
+
+    vertexWithRidgeList_.push_back(VertexWithRidge(globalVertex, globalRidgeList));
+  }
 }
 
 void GraspContact::addToGUI(mc_rtc::gui::StateBuilder & gui,

--- a/src/Contact.cpp
+++ b/src/Contact.cpp
@@ -196,8 +196,8 @@ SurfaceContact::SurfaceContact(const std::string & name,
     for(size_t ridgeIdx = 0; ridgeIdx < fricPyramid_->localRidgeList_.size(); ridgeIdx++)
     {
       const auto & localRidge = fricPyramid_->localRidgeList_[ridgeIdx];
-      auto colIdx =
-          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      auto colIdx = static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum()
+                    + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       localGraspMat_.col(colIdx) << localVertex.cross(localRidge), localRidge;
     }
@@ -230,8 +230,8 @@ void SurfaceContact::updateGlobalVertices(const sva::PTransformd & pose)
     for(size_t ridgeIdx = 0; ridgeIdx < globalRidgeList.size(); ridgeIdx++)
     {
       const auto & globalRidge = globalRidgeList[ridgeIdx];
-      auto colIdx =
-        static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      auto colIdx = static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum()
+                    + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
     }
@@ -291,8 +291,8 @@ GraspContact::GraspContact(const std::string & name,
     for(size_t ridgeIdx = 0; ridgeIdx < localRidgeList.size(); ridgeIdx++)
     {
       const auto & localRidge = localRidgeList[ridgeIdx];
-      auto colIdx =
-          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      auto colIdx = static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum()
+                    + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       localGraspMat_.col(colIdx) << localVertex.cross(localRidge), localRidge;
     }
@@ -325,8 +325,8 @@ void GraspContact::updateGlobalVertices(const sva::PTransformd & pose)
     for(size_t ridgeIdx = 0; ridgeIdx < globalRidgeList.size(); ridgeIdx++)
     {
       const auto & globalRidge = globalRidgeList[ridgeIdx];
-      auto colIdx =
-          static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum() + static_cast<Eigen::DenseIndex>(ridgeIdx);
+      auto colIdx = static_cast<Eigen::DenseIndex>(vertexIdx) * fricPyramid_->ridgeNum()
+                    + static_cast<Eigen::DenseIndex>(ridgeIdx);
       // The top 3 rows are moment, the bottom 3 rows are force.
       graspMat_.col(colIdx) << globalVertex.cross(globalRidge), globalRidge;
     }

--- a/tests/src/TestContact.cpp
+++ b/tests/src/TestContact.cpp
@@ -128,6 +128,44 @@ TEST(TestContact, calcWrench)
   ForceColl::calcWrenchList(ForceColl::getContactVecFromMap(contactUnorderedMap), wrenchRatio);
 }
 
+TEST(TestContact, UpdateSurfaceContactVertices)
+{
+  sva::PTransformd targetPose(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5));
+  auto originalContact = std::make_shared<ForceColl::SurfaceContact>(
+    "OriginalContact", 1.0,
+    std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0), Eigen::Vector3d(0.0, 0.0, 0.1)},
+    sva::PTransformd::Identity());
+  auto targetContact = std::make_shared<ForceColl::SurfaceContact>(
+    "TargetContact", 1.0,
+    std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0), Eigen::Vector3d(0.0, 0.0, 0.1)},
+    targetPose);
+  originalContact->updateGlobalVertices(targetPose);
+  EXPECT_LT((originalContact->graspMat_ - targetContact->graspMat_).norm(), 1e-8) << "originalContact:\n"
+                                                                                  << originalContact->graspMat_ << std::endl
+                                                                                  << "targetContact:\n"
+                                                                                  << targetContact->graspMat_ << std::endl;
+}
+
+TEST(TestContact, UpdateGraspContactVertices)
+{
+  sva::PTransformd targetPose(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5));
+  auto originalContact = std::make_shared<ForceColl::GraspContact>(
+    "OriginalContact", 1.0,
+    std::vector<sva::PTransformd>{sva::PTransformd(sva::RotX(-1 * M_PI / 2), Eigen::Vector3d(-0.1, -0.1, 0.0)),
+      sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(-0.1, 0.1, 0.0)), sva::PTransformd(sva::RotX(0.0), Eigen::Vector3d(0.0, 0.0, 0.1))},
+    sva::PTransformd::Identity());
+  auto targetContact = std::make_shared<ForceColl::GraspContact>(
+    "TargetContact", 1.0,
+    std::vector<sva::PTransformd>{sva::PTransformd(sva::RotX(-1 * M_PI / 2), Eigen::Vector3d(-0.1, -0.1, 0.0)),
+      sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(-0.1, 0.1, 0.0)), sva::PTransformd(sva::RotX(0.0), Eigen::Vector3d(0.0, 0.0, 0.1))},
+    targetPose);
+  originalContact->updateGlobalVertices(targetPose);
+  EXPECT_LT((originalContact->graspMat_ - targetContact->graspMat_).norm(), 1e-8) << "originalContact:\n"
+                                                                                  << originalContact->graspMat_ << std::endl
+                                                                                  << "targetContact:\n"
+                                                                                  << targetContact->graspMat_ << std::endl;
+}
+
 int main(int argc, char ** argv)
 {
   testing::InitGoogleTest(&argc, argv);

--- a/tests/src/TestContact.cpp
+++ b/tests/src/TestContact.cpp
@@ -132,38 +132,44 @@ TEST(TestContact, UpdateSurfaceContactVertices)
 {
   sva::PTransformd targetPose(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5));
   auto originalContact = std::make_shared<ForceColl::SurfaceContact>(
-    "OriginalContact", 1.0,
-    std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0), Eigen::Vector3d(0.0, 0.0, 0.1)},
-    sva::PTransformd::Identity());
+      "OriginalContact", 1.0,
+      std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0),
+                                   Eigen::Vector3d(0.0, 0.0, 0.1)},
+      sva::PTransformd::Identity());
   auto targetContact = std::make_shared<ForceColl::SurfaceContact>(
-    "TargetContact", 1.0,
-    std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0), Eigen::Vector3d(0.0, 0.0, 0.1)},
-    targetPose);
+      "TargetContact", 1.0,
+      std::vector<Eigen::Vector3d>{Eigen::Vector3d(-0.1, -0.1, 0.0), Eigen::Vector3d(-0.1, 0.1, 0.0),
+                                   Eigen::Vector3d(0.0, 0.0, 0.1)},
+      targetPose);
   originalContact->updateGlobalVertices(targetPose);
-  EXPECT_LT((originalContact->graspMat_ - targetContact->graspMat_).norm(), 1e-8) << "originalContact:\n"
-                                                                                  << originalContact->graspMat_ << std::endl
-                                                                                  << "targetContact:\n"
-                                                                                  << targetContact->graspMat_ << std::endl;
+  EXPECT_LT((originalContact->graspMat_ - targetContact->graspMat_).norm(), 1e-8)
+      << "originalContact:\n"
+      << originalContact->graspMat_ << std::endl
+      << "targetContact:\n"
+      << targetContact->graspMat_ << std::endl;
 }
 
 TEST(TestContact, UpdateGraspContactVertices)
 {
   sva::PTransformd targetPose(sva::RotX(M_PI / 2), Eigen::Vector3d(0.0, 0.5, -0.5));
   auto originalContact = std::make_shared<ForceColl::GraspContact>(
-    "OriginalContact", 1.0,
-    std::vector<sva::PTransformd>{sva::PTransformd(sva::RotX(-1 * M_PI / 2), Eigen::Vector3d(-0.1, -0.1, 0.0)),
-      sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(-0.1, 0.1, 0.0)), sva::PTransformd(sva::RotX(0.0), Eigen::Vector3d(0.0, 0.0, 0.1))},
-    sva::PTransformd::Identity());
+      "OriginalContact", 1.0,
+      std::vector<sva::PTransformd>{sva::PTransformd(sva::RotX(-1 * M_PI / 2), Eigen::Vector3d(-0.1, -0.1, 0.0)),
+                                    sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(-0.1, 0.1, 0.0)),
+                                    sva::PTransformd(sva::RotX(0.0), Eigen::Vector3d(0.0, 0.0, 0.1))},
+      sva::PTransformd::Identity());
   auto targetContact = std::make_shared<ForceColl::GraspContact>(
-    "TargetContact", 1.0,
-    std::vector<sva::PTransformd>{sva::PTransformd(sva::RotX(-1 * M_PI / 2), Eigen::Vector3d(-0.1, -0.1, 0.0)),
-      sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(-0.1, 0.1, 0.0)), sva::PTransformd(sva::RotX(0.0), Eigen::Vector3d(0.0, 0.0, 0.1))},
-    targetPose);
+      "TargetContact", 1.0,
+      std::vector<sva::PTransformd>{sva::PTransformd(sva::RotX(-1 * M_PI / 2), Eigen::Vector3d(-0.1, -0.1, 0.0)),
+                                    sva::PTransformd(sva::RotX(M_PI / 2), Eigen::Vector3d(-0.1, 0.1, 0.0)),
+                                    sva::PTransformd(sva::RotX(0.0), Eigen::Vector3d(0.0, 0.0, 0.1))},
+      targetPose);
   originalContact->updateGlobalVertices(targetPose);
-  EXPECT_LT((originalContact->graspMat_ - targetContact->graspMat_).norm(), 1e-8) << "originalContact:\n"
-                                                                                  << originalContact->graspMat_ << std::endl
-                                                                                  << "targetContact:\n"
-                                                                                  << targetContact->graspMat_ << std::endl;
+  EXPECT_LT((originalContact->graspMat_ - targetContact->graspMat_).norm(), 1e-8)
+      << "originalContact:\n"
+      << originalContact->graspMat_ << std::endl
+      << "targetContact:\n"
+      << targetContact->graspMat_ << std::endl;
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
Currently, the global vertices of a contact used for wrench distribution is computed in the constructor. However, if pose of the contact is modified from the pre-defined one by controller, they need to be recomputed based on the new pose.
This PR extract the part of computing global vertices based on the pose of the contact as a new function `updateGlobalVertices`.